### PR TITLE
Add cosmos DB utilities (initial)

### DIFF
--- a/KServerTools/AzureCosmosDb/AzureCosmosDb.cs
+++ b/KServerTools/AzureCosmosDb/AzureCosmosDb.cs
@@ -1,0 +1,93 @@
+namespace KServerTools.Common;
+
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Caching.Memory;
+
+internal class AzureCosmosDb<T, C>(T configuration, C credential) : IAzureCosmosDb<T>, IDisposable where T : IAzureCosmosDbConfiguration where C : ITokenCredentialService {
+    private readonly T configuration = configuration;
+    private readonly C credential = credential;
+    protected readonly MemoryCache memoryCache = new(new MemoryCacheOptions());
+    protected static readonly MemoryCacheEntryOptions memoryCacheEntryOptions = new() {
+        SlidingExpiration = TimeSpan.FromMinutes(50)
+    };
+
+    public async Task<bool> CreateDatabaseAsync(string database, CancellationToken cancellationToken) {
+        ArgumentNullException.ThrowIfNullOrEmpty(database, nameof(database));
+        CosmosClient client = await this.GetClient(database);
+        DatabaseResponse response = await client.CreateDatabaseIfNotExistsAsync(database, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return response.StatusCode == HttpStatusCode.Created;
+    }
+
+    public async Task<bool> CreateContainerAsync(string database, string container, string partitionKey, CancellationToken cancellationToken) {
+        ArgumentNullException.ThrowIfNullOrEmpty(container, nameof(container));
+        ArgumentNullException.ThrowIfNullOrEmpty(partitionKey, nameof(partitionKey));
+        CosmosClient client = await this.GetClient(database);
+        Database cosmosDatabase = client.GetDatabase(database);
+        ContainerResponse response = await cosmosDatabase.CreateContainerIfNotExistsAsync(container, partitionKey, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return response.StatusCode == HttpStatusCode.Created;
+    }
+
+    public async Task<I> GetItemAsync<I>(string database, string container, string itemId, string partitionKey, CancellationToken cancellationToken) where I : IComosEntity {
+        ArgumentNullException.ThrowIfNullOrEmpty(database, nameof(database));
+        ArgumentNullException.ThrowIfNullOrEmpty(container, nameof(container));
+        ArgumentNullException.ThrowIfNullOrEmpty(partitionKey, nameof(partitionKey));
+        Container cosmosContainer = await this.GetContainer(database, container, cancellationToken).ConfigureAwait(false);
+        ItemResponse<I> response = await cosmosContainer.ReadItemAsync<I>(itemId, new PartitionKey(partitionKey), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return response.Resource;
+    }
+
+    public Task<IEnumerable<I>> GetItemsAsync<I>(string database, string container, string query, CancellationToken cancellationToken) where I : IComosEntity
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<I> AddItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I : IComosEntity {
+        ArgumentNullException.ThrowIfNullOrEmpty(database, nameof(database));
+        ArgumentNullException.ThrowIfNullOrEmpty(container, nameof(container));
+
+        Container cosmosContainer = await this.GetContainer(database, container, cancellationToken).ConfigureAwait(false);
+        ItemResponse<I> response = await cosmosContainer.CreateItemAsync<I>(item, new PartitionKey(item.PartitionKey), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return response.Resource;
+    }
+
+    public async Task<I> UpdateItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I : IComosEntity {
+        ArgumentNullException.ThrowIfNullOrEmpty(database, nameof(database));
+        ArgumentNullException.ThrowIfNullOrEmpty(container, nameof(container));
+        Container cosmosContainer = await this.GetContainer(database, container, cancellationToken).ConfigureAwait(false);
+        ItemResponse<I> response = await cosmosContainer.UpsertItemAsync<I>(item, new PartitionKey(item.PartitionKey), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return response.Resource;
+    }
+
+    public async Task DeleteItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I : IComosEntity {
+        ArgumentNullException.ThrowIfNullOrEmpty(database, nameof(database));
+        ArgumentNullException.ThrowIfNullOrEmpty(container, nameof(container));
+        Container cosmosContainer = await this.GetContainer(database, container, cancellationToken).ConfigureAwait(false);
+        ItemResponse<I> response = await cosmosContainer.DeleteItemAsync<I>(item.Id, new PartitionKey(item.PartitionKey), cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Dispose() {
+        this.memoryCache?.Dispose();
+    }
+
+    private async ValueTask<CosmosClient> GetClient(string databaseName) {
+        CosmosClient client;
+        string key = $"{databaseName}";
+        if (!this.memoryCache.TryGetValue(key, out client!)) {
+            if (this.credential != null) {
+                client = new(this.configuration.EndpointUri, await this.credential.GetCredential(CancellationToken.None));
+            } else {
+                client = new(this.configuration.EndpointUri, this.configuration.PrimaryKey);
+            }
+            this.memoryCache.Set(key, client, memoryCacheEntryOptions);
+        }
+
+        return client;
+    }
+
+    private async Task<Container> GetContainer(string database, string container, CancellationToken cancellationToken) {
+        CosmosClient client = await this.GetClient(database);
+        Database cosmosDatabase = client.GetDatabase(database);
+        return cosmosDatabase.GetContainer(container);
+    }
+}

--- a/KServerTools/AzureCosmosDb/AzureCosmosDb.cs
+++ b/KServerTools/AzureCosmosDb/AzureCosmosDb.cs
@@ -28,7 +28,7 @@ internal class AzureCosmosDb<T, C>(T configuration, C credential) : IAzureCosmos
         return response.StatusCode == HttpStatusCode.Created;
     }
 
-    public async Task<I> GetItemAsync<I>(string database, string container, string itemId, string partitionKey, CancellationToken cancellationToken) where I : IComosEntity {
+    public async Task<I> GetItemAsync<I>(string database, string container, string itemId, string partitionKey, CancellationToken cancellationToken) where I : ICosmosEntity {
         ArgumentNullException.ThrowIfNullOrEmpty(database, nameof(database));
         ArgumentNullException.ThrowIfNullOrEmpty(container, nameof(container));
         ArgumentNullException.ThrowIfNullOrEmpty(partitionKey, nameof(partitionKey));
@@ -37,12 +37,12 @@ internal class AzureCosmosDb<T, C>(T configuration, C credential) : IAzureCosmos
         return response.Resource;
     }
 
-    public Task<IEnumerable<I>> GetItemsAsync<I>(string database, string container, string query, CancellationToken cancellationToken) where I : IComosEntity
+    public Task<IEnumerable<I>> GetItemsAsync<I>(string database, string container, string query, CancellationToken cancellationToken) where I : ICosmosEntity
     {
         throw new NotImplementedException();
     }
 
-    public async Task<I> AddItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I : IComosEntity {
+    public async Task<I> AddItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I : ICosmosEntity {
         ArgumentNullException.ThrowIfNullOrEmpty(database, nameof(database));
         ArgumentNullException.ThrowIfNullOrEmpty(container, nameof(container));
 
@@ -51,7 +51,7 @@ internal class AzureCosmosDb<T, C>(T configuration, C credential) : IAzureCosmos
         return response.Resource;
     }
 
-    public async Task<I> UpdateItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I : IComosEntity {
+    public async Task<I> UpdateItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I : ICosmosEntity {
         ArgumentNullException.ThrowIfNullOrEmpty(database, nameof(database));
         ArgumentNullException.ThrowIfNullOrEmpty(container, nameof(container));
         Container cosmosContainer = await this.GetContainer(database, container, cancellationToken).ConfigureAwait(false);
@@ -59,7 +59,7 @@ internal class AzureCosmosDb<T, C>(T configuration, C credential) : IAzureCosmos
         return response.Resource;
     }
 
-    public async Task DeleteItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I : IComosEntity {
+    public async Task DeleteItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I : ICosmosEntity {
         ArgumentNullException.ThrowIfNullOrEmpty(database, nameof(database));
         ArgumentNullException.ThrowIfNullOrEmpty(container, nameof(container));
         Container cosmosContainer = await this.GetContainer(database, container, cancellationToken).ConfigureAwait(false);

--- a/KServerTools/AzureCosmosDb/AzureCosmosDb.cs
+++ b/KServerTools/AzureCosmosDb/AzureCosmosDb.cs
@@ -74,10 +74,15 @@ internal class AzureCosmosDb<T, C>(T configuration, C credential) : IAzureCosmos
         CosmosClient client;
         string key = $"{databaseName}";
         if (!this.memoryCache.TryGetValue(key, out client!)) {
+            var options = new CosmosClientOptions {
+                SerializerOptions = new CosmosSerializationOptions {
+                    PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+                }
+            };
             if (this.credential != null) {
-                client = new(this.configuration.EndpointUri, await this.credential.GetCredential(CancellationToken.None));
+                client = new(this.configuration.EndpointUri, await this.credential.GetCredential(CancellationToken.None), options);
             } else {
-                client = new(this.configuration.EndpointUri, this.configuration.PrimaryKey);
+                client = new(this.configuration.EndpointUri, this.configuration.PrimaryKey, options);
             }
             this.memoryCache.Set(key, client, memoryCacheEntryOptions);
         }

--- a/KServerTools/AzureCosmosDb/IComosEntity.cs
+++ b/KServerTools/AzureCosmosDb/IComosEntity.cs
@@ -4,3 +4,8 @@ public interface IComosEntity: IEntity {
     string Id { get; }
     string PartitionKey { get; }
 }
+
+public interface IComosEntityLookup : IEntityLookup {
+    string Id { get; }
+    string PartitionKey { get; }
+}

--- a/KServerTools/AzureCosmosDb/IComosEntity.cs
+++ b/KServerTools/AzureCosmosDb/IComosEntity.cs
@@ -1,6 +1,6 @@
 namespace KServerTools.Common;
 
-public interface IComosEntity: IEntity {
+public interface ICosmosEntity: IEntity {
     string Id { get; }
     string PartitionKey { get; }
 }

--- a/KServerTools/AzureCosmosDb/IComosEntity.cs
+++ b/KServerTools/AzureCosmosDb/IComosEntity.cs
@@ -1,0 +1,6 @@
+namespace KServerTools.Common;
+
+public interface IComosEntity: IEntity {
+    string Id { get; }
+    string PartitionKey { get; }
+}

--- a/KServerTools/Credentials/ServicePrincipalConfiguration.cs
+++ b/KServerTools/Credentials/ServicePrincipalConfiguration.cs
@@ -1,34 +1,32 @@
+
 namespace KServerTools.Common;
 
 /// <summary>
 /// Represents the configuration settings for a service principal.
 /// </summary>
-public class ServicePrincipalConfiguration : IServicePrincipalConfig {
-    private string? secret = null;
-    private DateTimeOffset credentialExpiration = DateTimeOffset.MinValue;
+public abstract class ServicePrincipalConfiguration : IServicePrincipalConfig {
     /// <summary>
     /// Gets or sets the application ID of the service principal.
     /// </summary>
     public required string ApplicationId { get; set; }
+    
     /// <summary>
     /// Gets or sets the tenant ID of the service principal.
     /// </summary>
     public required string TenantId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the secret data of the service principal.
+    /// </summary>
     public required string SecretData { get; set; }
+
+    /// <summary>
+    /// Gets the type of credential.
+    /// </summary>
     public ServiceCredentalType CredentialType { get => ServiceCredentalType.ServicePrincipal; }
 
-    [Obsolete("Owning service should set")]
-    public ISecretResolver? SecretResolver { get; set; }
-
-    public async Task<string> GetResolvedSecret(CancellationToken cancellationToken) {
-        InternalServerErrorException.ThrowIfArgumentIsNull(this.SecretResolver, "SecretResolver must be set before calling GetResolvedSecret. This must be done during dependency injection.");
-        if (this.secret == null || DateTimeOffset.UtcNow > this.credentialExpiration) {
-            this.credentialExpiration = DateTimeOffset.UtcNow.AddMinutes(45);
-            this.secret = await this.SecretResolver!
-                .Resolve(this.SecretData, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        return this.secret;
-    }
+    /// <summary>
+    /// Get's the secret for the service principal.
+    /// </summary>
+    public abstract Task<string> GetSecret(CancellationToken cancellationToken);
 }

--- a/KServerTools/Credentials/ServicePrincipalCredential.cs
+++ b/KServerTools/Credentials/ServicePrincipalCredential.cs
@@ -19,7 +19,7 @@ using Azure.Identity;
 /// </remarks>
 internal class ServicePrincipalCredential<T>(T config) : TokenCredentialBase<T>(config), IServicePrincipalCredential<T> where T: IServicePrincipalConfig {
     public override async Task<TokenCredential> GetCredential(CancellationToken cancellationToken) {
-        string secret = await this.Config.GetResolvedSecret(cancellationToken).ConfigureAwait(false);
+        string secret = await this.Config.GetSecret(cancellationToken).ConfigureAwait(false);
         return new ClientSecretCredential(
             this.Config.TenantId, 
             this.Config.ApplicationId, 

--- a/KServerTools/DependencyHelper.cs
+++ b/KServerTools/DependencyHelper.cs
@@ -111,6 +111,15 @@ public static class DependencyHelper {
             .AddSingleton<IAzureStorageService<T>, AzureStorageService<T, C>>();
     }
 
+    public static IServiceCollection KSTAddAzureCosmosDb<T, C>(this IServiceCollection services, string sectionName) where T: class, IAzureCosmosDbConfiguration where C: class, ITokenCredentialService {
+        ArgumentNullException.ThrowIfNullOrEmpty(sectionName, nameof(sectionName));
+        return services.AddSingleton<T>(impl => {
+                ConfigurationHelper configHelper = impl.GetConfigurationHelper();
+                return configHelper.TryGet<T>(sectionName) ?? throw new InvalidOperationException("AzureCosmosDbConfiguration could not be retrieved.");
+            })
+            .AddSingleton<IAzureCosmosDb<T>, AzureCosmosDb<T, C>>();
+    }
+
     /// <summary>
     /// Adds a Azure Storage Queue service to the service collection. It can be referenced like IAzureStorageQueueService<typeparamref name="T"/>>
     /// </summary>

--- a/KServerTools/Helpers/ConfigurationHelper.cs
+++ b/KServerTools/Helpers/ConfigurationHelper.cs
@@ -26,7 +26,8 @@ public class ConfigurationHelper(IConfiguration configuration) {
 
             return null;
         }
-        catch {
+        catch (Exception ex) {
+            Console.WriteLine($"Error reading configuration section {sectionName}: {ex.Message}");
             return null;
         }
     }

--- a/KServerTools/Helpers/SecretResolver.cs
+++ b/KServerTools/Helpers/SecretResolver.cs
@@ -6,10 +6,6 @@ internal class SecretResolver : ISecretResolver {
         Local,
     }
 
-    public SecretResolver() { 
-        Console.WriteLine("SecretResolver created.");
-    }
-
     private IAzureKeyVaultInternal? keyVaultService = null;
 
     public async ValueTask<string> Resolve(string secret, CancellationToken cancellationToken) {

--- a/KServerTools/IAzureCosmosDb.cs
+++ b/KServerTools/IAzureCosmosDb.cs
@@ -1,0 +1,11 @@
+namespace KServerTools.Common;
+
+public interface IAzureCosmosDb<T> where T : IAzureCosmosDbConfiguration {
+    Task<bool> CreateDatabaseAsync(string database, CancellationToken cancellationToken);
+    Task<bool> CreateContainerAsync(string database, string container, string partitionKey, CancellationToken cancellationToken);
+    Task<I> GetItemAsync<I>(string database, string container, string itemId, string partitionKey, CancellationToken cancellationToken) where I: IComosEntity;
+    Task<IEnumerable<I>> GetItemsAsync<I>(string database, string container, string query, CancellationToken cancellationToken) where I: IComosEntity;
+    Task<I> AddItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I: IComosEntity;
+    Task<I> UpdateItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I: IComosEntity;
+    Task DeleteItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I: IComosEntity;
+}

--- a/KServerTools/IAzureCosmosDb.cs
+++ b/KServerTools/IAzureCosmosDb.cs
@@ -3,9 +3,9 @@ namespace KServerTools.Common;
 public interface IAzureCosmosDb<T> where T : IAzureCosmosDbConfiguration {
     Task<bool> CreateDatabaseAsync(string database, CancellationToken cancellationToken);
     Task<bool> CreateContainerAsync(string database, string container, string partitionKey, CancellationToken cancellationToken);
-    Task<I> GetItemAsync<I>(string database, string container, string itemId, string partitionKey, CancellationToken cancellationToken) where I: IComosEntity;
-    Task<IEnumerable<I>> GetItemsAsync<I>(string database, string container, string query, CancellationToken cancellationToken) where I: IComosEntity;
-    Task<I> AddItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I: IComosEntity;
-    Task<I> UpdateItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I: IComosEntity;
-    Task DeleteItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I: IComosEntity;
+    Task<I> GetItemAsync<I>(string database, string container, string itemId, string partitionKey, CancellationToken cancellationToken) where I: ICosmosEntity;
+    Task<IEnumerable<I>> GetItemsAsync<I>(string database, string container, string query, CancellationToken cancellationToken) where I: ICosmosEntity;
+    Task<I> AddItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I: ICosmosEntity;
+    Task<I> UpdateItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I: ICosmosEntity;
+    Task DeleteItemAsync<I>(string database, string container, I item, CancellationToken cancellationToken) where I: ICosmosEntity;
 }

--- a/KServerTools/IAzureCosmosDbConfiguration.cs
+++ b/KServerTools/IAzureCosmosDbConfiguration.cs
@@ -10,8 +10,7 @@ public class AzureCosmosDbConfiguration : IAzureCosmosDbConfiguration {
     public required string EndpointUri { get; set; }
     public string PrimaryKey { 
         get {
-            this.primaryKey = this.GetSecret(CancellationToken.None).Result;
-            return this.primaryKey;
+            return this.primaryKey ?? string.Empty;
         }
         set {
             this.primaryKey = value;

--- a/KServerTools/IAzureCosmosDbConfiguration.cs
+++ b/KServerTools/IAzureCosmosDbConfiguration.cs
@@ -1,0 +1,23 @@
+namespace KServerTools.Common;
+
+public interface IAzureCosmosDbConfiguration {
+    string EndpointUri { get; set; }
+    string PrimaryKey { get; set; }
+}
+
+public class AzureCosmosDbConfiguration : IAzureCosmosDbConfiguration {
+    private string? primaryKey;
+    public required string EndpointUri { get; set; }
+    public string PrimaryKey { 
+        get {
+            this.primaryKey = this.GetSecret(CancellationToken.None).Result;
+            return this.primaryKey;
+        }
+        set {
+            this.primaryKey = value;
+        }
+    }
+    public virtual Task<string> GetSecret(CancellationToken cancellationToken) {
+        return Task.FromResult(this.primaryKey ?? string.Empty);
+    }
+}

--- a/KServerTools/ICredentialConfig.cs
+++ b/KServerTools/ICredentialConfig.cs
@@ -5,18 +5,11 @@ namespace KServerTools.Common;
 /// </summary>
 public interface ICredentialConfig {
     public ServiceCredentalType CredentialType { get; }
-
-    /// <summary>
-    /// Get the resolved secret.
-    /// </summary>
-    Task<string> GetResolvedSecret(CancellationToken cancellationToken);
 }
 
 public interface IServicePrincipalConfig : ICredentialConfig {
     public string ApplicationId { get; set; }
     public string TenantId { get; set; }
     public string SecretData { get; set; }
-
-    [Obsolete("Owning service should set")]
-    public ISecretResolver? SecretResolver { get; set; } // needs to be set via DI
+    public Task<string> GetSecret(CancellationToken cancellationToken);
 }

--- a/KServerTools/IRepository.cs
+++ b/KServerTools/IRepository.cs
@@ -18,7 +18,7 @@ public interface IEntityLookup {
 /// </summary>
 /// <typeparam name="M">The Model that function call will interact or return</typeparam>
 /// <typeparam name="L">The look up model. They can be the same, but the look up model is usually a smaller record.</typeparam>
-public interface IRepository<M, L> where M : IEntity where L : IEntityLookup {
+public interface IRepository<M, L> where M : class, IEntity where L : class, IEntityLookup {
     Task<M> GetAsync(L lookup, CancellationToken cancellationToken);
     Task<bool> CreateOrUpdateAsync(M model, CancellationToken cancellationToken);
     Task<bool> DeleteAsync(L lookup, CancellationToken cancellationToken);
@@ -29,6 +29,6 @@ public interface IRepository<M, L> where M : IEntity where L : IEntityLookup {
 /// </summary>
 /// <typeparam name="M">The Model that function call will interact or return</typeparam>
 /// <typeparam name="L">The look up model. They can be the same, but the look up model is usually a smaller record.</typeparam>
-public interface IGetMultiple<M, L> where M : IEntity where L : IEntityLookup {
+public interface IGetMultiple<M, L> where M : class, IEntity where L : class, IEntityLookup {
     Task<IEnumerable<M>> GetMultipleAsync(L lookup, CancellationToken cancellationToken);
 }

--- a/KServerTools/KServerTools.csproj
+++ b/KServerTools/KServerTools.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.47.2" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.3" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />

--- a/KServerTools/KServerTools.csproj
+++ b/KServerTools/KServerTools.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <!-- Nuget Info -->
     <PackageId>KServerTools</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <Authors>judellam</Authors>
     <Description>Common set of tools used to interact with Azure and a Kestrel Service</Description>
     <PackageTag>kestrel, azure, tools</PackageTag>

--- a/KServerTools/Logging/JsonStorageLogger.cs
+++ b/KServerTools/Logging/JsonStorageLogger.cs
@@ -48,7 +48,7 @@ internal class JsonStorageLogger<T, C> : IJsonLogger where T : AzureStorageServi
 
     public void Warn(string message, Exception? exception = null, long? latency = null, [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0, [CallerMemberName] string memberName = "") {
         string logEvent = LoggingUtilities.GetLogEvent(LogLevel.Warning, message, exception, filePath, lineNumber, memberName, accessor, requestContextAccessor, latency);
-        this.logger.LogInformation(logEvent);
+        this.logger.LogWarning(logEvent);
         this.logQueue.Enqueue(logEvent);
     }
 

--- a/KServerTools/Logging/JsonStorageLogger.cs
+++ b/KServerTools/Logging/JsonStorageLogger.cs
@@ -41,13 +41,13 @@ internal class JsonStorageLogger<T, C> : IJsonLogger where T : AzureStorageServi
     }
 
     public void Info(string message, long? latency = null, [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0, [CallerMemberName] string memberName = "") {
-        string logEvent = LoggingUtilities.GetLogEvent(LogLevel.Error, message, null, filePath, lineNumber, memberName, accessor, requestContextAccessor, latency);
+        string logEvent = LoggingUtilities.GetLogEvent(LogLevel.Information, message, null, filePath, lineNumber, memberName, accessor, requestContextAccessor, latency);
         this.logger.LogInformation(logEvent);
         this.logQueue.Enqueue(logEvent);
     }
 
     public void Warn(string message, Exception? exception = null, long? latency = null, [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0, [CallerMemberName] string memberName = "") {
-        string logEvent = LoggingUtilities.GetLogEvent(LogLevel.Error, message, exception, filePath, lineNumber, memberName, accessor, requestContextAccessor, latency);
+        string logEvent = LoggingUtilities.GetLogEvent(LogLevel.Warning, message, exception, filePath, lineNumber, memberName, accessor, requestContextAccessor, latency);
         this.logger.LogInformation(logEvent);
         this.logQueue.Enqueue(logEvent);
     }


### PR DESCRIPTION
Add wrapper and config classes to allow for cosmosDb.

Example Code

```
        serviceCollection
            .KSTAddAzureCosmosDb<AzureCosmosUserDbConfiguration, IDefaultCredential>("AzureCosmosDbConfiguration");
```

```
public interface IUserDataDb : IRepository<UserDataEntity?, UserDataLookup> {
}

internal class UserDataDatabase<A, T>(IAzureCosmosDb<A> azureCosmosDb) : IUserDataDbConfig {
    private readonly IAzureCosmosDb<A> azureCosmosDb = azureCosmosDb;
    public async Task<UserDataEntity?> GetAsync(UserDataLookup lookup, CancellationToken cancellationToken) {
        try {
            return await this.azureCosmosDb.GetItemAsync<UserDataEntity>(
                "database",
                "container",
                lookup.Id
                lookup.PartitionKey,
                cancellationToken).ConfigureAwait(false);
        } catch (CosmosException e) {
            if (e.StatusCode == HttpStatusCode.NotFound) {
                return null;
            }
            return null;
        }
    }
}
```